### PR TITLE
List EIDs

### DIFF
--- a/exe/ephemeral_calc
+++ b/exe/ephemeral_calc
@@ -100,14 +100,13 @@ eos
     count = ARGV.shift.to_i
     encryptor = EphemeralCalc::Encryptor.new identity_key, rotation_scalar
     start_quantum = beacon_time / 2**rotation_scalar
-    end_quantum = start_quantum + count
+    end_quantum = start_quantum + count - 1
     start_quantum.upto(end_quantum) do |quantum|
       start_time = quantum * 2**rotation_scalar
       end_time = start_time + 2**rotation_scalar
       eid = encryptor.get_identifier(start_time)
-      puts "Quantum: #{quantum} (#{start_time}s - #{end_time}s), EID: #{eid}"
+      puts "EID: #{eid}, Quantum: #{quantum} (#{seconds_display(start_time)} - #{seconds_display(end_time)})"
     end
-
   end
 
   def keygen
@@ -118,6 +117,19 @@ eos
 
   def to_hex(bytes)
     bytes.unpack("H*")[0].upcase
+  end
+
+  def seconds_display(seconds)
+    case
+    when seconds >= 86400
+      "#{seconds / 86400}d " + seconds_display(seconds % 86400)
+    when seconds >= 3600
+      "#{seconds / 3600}h " + seconds_display(seconds % 3600)
+    when seconds >= 60
+      "#{seconds / 60}m " + seconds_display(seconds % 60)
+    else
+      "#{seconds}s"
+    end
   end
 end
 


### PR DESCRIPTION
You use it like this:

```
# ephemeral_calc list <identity_key> <rotation_scaler> <start_beacon_time> <count>
ephemeral_calc list 0102030405060708090A111213141516 10 5000 100
```

That would list 100 EIDs starting at "beacon time" 5000 seconds.

You could do a search like this:

```
ephemeral_calc list 0102030405060708090A111213141516 10 5000 100 | grep 7D47A9D47C72EE6E
```

which outputs:

```
EID: 7D47A9D47C72EE6E, Quantum: 25 (7h 6m 40s - 7h 23m 44s)
```

EID calculation is pretty quick.  If you have a rotation scalar of 12 (rotates about 1 / hr), I can calculate a year's worth of EIDs in about a half second.  Unrelated, but this is partly why I'm not convinced that running a resolver service is all that computationally difficult (at non-Google scale).
