### PR TITLE
Add support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 2.1.2
 before_install: gem install bundler -v 1.14.3
 install: bin/setup
+script: bin/rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1.2
-before_install: gem install bundler -v 1.10.6
+before_install: gem install bundler -v 1.14.3
 install: bin/setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.2
+  - 2.1.10
+  - 2.2.2
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 before_install: gem install bundler -v 1.14.3
 install: bin/setup
 script: bin/rspec

--- a/ephemeral_calc.gemspec
+++ b/ephemeral_calc.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "webmock"
   spec.add_development_dependency "rake-compiler"
 end

--- a/ephemeral_calc.gemspec
+++ b/ephemeral_calc.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "rake-compiler"
 end

--- a/lib/ephemeral_calc/encryptor.rb
+++ b/lib/ephemeral_calc/encryptor.rb
@@ -84,7 +84,7 @@ module EphemeralCalc
     end
 
     def do_aes_encryption(key, data)
-      aes = OpenSSL::Cipher::Cipher.new("AES-128-ECB")
+      aes = OpenSSL::Cipher.new("AES-128-ECB")
       aes.encrypt
       aes.key = key
       #aes.iv = "what do I put here?"

--- a/lib/ephemeral_calc/encryptor.rb
+++ b/lib/ephemeral_calc/encryptor.rb
@@ -86,8 +86,7 @@ module EphemeralCalc
     def do_aes_encryption(key, data)
       aes = OpenSSL::Cipher.new("AES-128-ECB")
       aes.encrypt
-      aes.key = key
-      #aes.iv = "what do I put here?"
+      aes.key = key[0, aes.key_len]
       aes.update(data) + aes.final
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,3 @@ end
 
 # Require our gem
 require 'ephemeral_calc'
-
-# Include Mocking Web Requests Globally
-require 'webmock/rspec'
-WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,5 +103,18 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
+# `Warning` was added in Ruby 2.4 and allows us to customize Ruby warnings
+if defined?(Warning)
+  # Use a module to prevent overwriting the original method and allowing for
+  # easy inspection of the ancestor chain to understand this has been monkey
+  # patched.
+  module RaiseOnWarnings
+    def warn(str)
+      raise SyntaxError, str, caller
+    end
+  end
+  Warning.extend RaiseOnWarnings
+end
+
 # Require our gem
 require 'ephemeral_calc'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,12 +40,19 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
@@ -62,6 +69,11 @@ RSpec.configure do |config|
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
   config.warnings = true
+
+  # Turns warnings into errors. This will treat RSpec warnings as failures.
+  # Most RSpec warnings are related to potential false positive results which
+  # are things we'd like to avoid.
+  config.raise_on_warning = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
Ruby 2.4 deprecated `OpenSSL::Cipher::Cipher`:

    warning: constant OpenSSL::Cipher::Cipher is deprecated

The first `Cipher` class constant is all that is necessary to create a new cipher object. This class's constructor accepts the same string as we have been using and is available in all current versions of Ruby.

Ruby 2.4 changed the behavior of `OpenSSL::Cipher#key=` to check the key size before continuing:

    ArgumentError:
      key must be 16 bytes

In general this is a good thing. When there is a key size mismatch there could be incorrect underlying assumptions about what the does to the encryption. For example, since passwords are generally stronger the longer they are I can easily see someone thinking this applies to the cipher key as well. But that would depend on the algorithm and is not generally true for block algorithms. Similarly, if the key is too short what happens? Is the cipher supposed to pad the key? With what character? This may also be dependent on the algorithm or may simply not be allowed.

Prior to Ruby 2.4 it did ensure that the key wasn't shorter than necessary for the algorithm. This simply compliments that by checking that it doesn't exceed it either.

When computing the EID value the generation of the temporary key produces text twice the length of the key. We are expected to truncate this to 128-bits to use as the key for the final round of computation. We were relying on the fact that the Ruby AES 128-ECB algorithm implementation had been doing this for us. However, now that we support Ruby 2.4 we can no longer rely on that and must perform all truncation ourselves.

To be robust against future changes this asks the cipher algorithm for the expected key length and uses that. Ruby will not pad the slice so if it is not long enough we will receive an error in the future as well. The spec does not state what should be used to pad the key. In fact based on the spec we should never hit this situation. If we do, there is definitely some sort of error and we do want that to be exposed.

Lastly, Ruby 2.4 exposed the Ruby warnings method (those reported with CLI flag `-W2`) in a new module `Warning`. As this is a gem we should strive to write warning free code. By using this new `Warning` the specs now raise a `SyntaxError` when a Ruby warning is encountered.